### PR TITLE
DEVOPS-8491: Pin all GitHub Actions to SHA256 hashes

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,12 +15,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495  # v3
         with:
           go-version: 1.19
           cache: true
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757  # v3
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495  # v3
         with:
           go-version: ${{ matrix.go }}
           cache: true
@@ -30,7 +30,7 @@ jobs:
           git --no-pager diff && [[ 0 -eq $(git status --porcelain | wc -l) ]]
 
       - name: Go Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc  # v3
         with:
           version: ${{ matrix.golangci }}
           args: "--out-${NO_FUTURE}format colored-line-number"

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
Pin external GitHub Actions to SHA256 hashes for supply chain security.

**References:**
- DEVOPS-8490: GitHub Actions SHA pinning initiative
- DEVOPS-8491: Shai Hulud worm remediation

**Changes:**
- Only external actions (actions/*, docker/*, etc.) are modified
- Internal pipelines-library references remain unchanged
- Version comments added for readability (e.g., # v4)